### PR TITLE
implement-parity-scale-codec for sgx-externalities' types + minor improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2382,8 +2382,10 @@ dependencies = [
 name = "sgx-externalities"
 version = "0.3.0"
 dependencies = [
+ "derive_more",
  "environmental",
  "log",
+ "parity-scale-codec",
  "sgx_serialize",
  "sgx_serialize_derive",
  "sgx_tstd",

--- a/substrate-sgx/externalities/Cargo.toml
+++ b/substrate-sgx/externalities/Cargo.toml
@@ -5,6 +5,8 @@ authors = ["Integritee AG <hello@integritee.network> and Parity Technologies <ad
 edition = "2018"
 
 [dependencies]
+codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive", "chain-error"]}
+derive_more = "0.99.16"
 environmental = { version = "1.0.1", default-features = false}
 sgx_tstd      = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git", features = ["untrusted_fs","net","backtrace"]}
 sgx_types     = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git"}

--- a/substrate-sgx/externalities/src/codec_impl.rs
+++ b/substrate-sgx/externalities/src/codec_impl.rs
@@ -1,5 +1,5 @@
 
-//! Implement `parity-scale-codec` for the externalities
+//! Implement `parity-scale-codec` for the externalities.
 //!
 //! This is little workaround, as `Encode` and `Decode` can't directly be implemented on `HashMap`.
 

--- a/substrate-sgx/externalities/src/codec_impl.rs
+++ b/substrate-sgx/externalities/src/codec_impl.rs
@@ -1,12 +1,11 @@
-
 //! Implement `parity-scale-codec` for the externalities.
 //!
 //! This is little workaround, as `Encode` and `Decode` can't directly be implemented on `HashMap`.
 
-use crate::{SgxExternalitiesType, SgxExternalitiesDiffType};
-use std::{vec::Vec};
-use sgx_serialize::{SerializeHelper, DeSerializable, DeSerializeHelper, Serializable};
-use codec::{Input, Decode, Encode};
+use crate::{SgxExternalitiesDiffType, SgxExternalitiesType};
+use codec::{Decode, Encode, Input};
+use sgx_serialize::{DeSerializable, DeSerializeHelper, Serializable, SerializeHelper};
+use std::vec::Vec;
 
 impl Encode for SgxExternalitiesType {
 	fn encode(&self) -> Vec<u8> {
@@ -38,15 +37,20 @@ fn encode_with_serialize<T: Serializable>(source: &T) -> Vec<u8> {
 		None => {
 			sgx_log::warn!("`encode_with_serialize` returned None");
 			Default::default()
-		}
+		},
 	}
 }
 
 fn decode_with_deserialize<I: Input, T: DeSerializable>(input: &mut I) -> Result<T, codec::Error> {
-	let mut buff = Vec::with_capacity(input.remaining_len()?
-		.ok_or_else(|| codec::Error::from("Could not read length from input data"))?);
+	let mut buff = Vec::with_capacity(
+		input
+			.remaining_len()?
+			.ok_or_else(|| codec::Error::from("Could not read length from input data"))?,
+	);
 
 	input.read(&mut buff)?;
 
-	DeSerializeHelper::<T>::new(buff).decode().ok_or_else(|| codec::Error::from("Could not decode with deserialize"))
+	DeSerializeHelper::<T>::new(buff)
+		.decode()
+		.ok_or_else(|| codec::Error::from("Could not decode with deserialize"))
 }

--- a/substrate-sgx/externalities/src/codec_impl.rs
+++ b/substrate-sgx/externalities/src/codec_impl.rs
@@ -1,0 +1,44 @@
+
+//! Implement `parity-scale-codec` for the externalities
+//!
+//! This is little workaround, as `Encode` and `Decode` can't directly be implemented on `HashMap`.
+
+use crate::{SgxExternalitiesType, SgxExternalitiesDiffType};
+use std::{vec::Vec};
+use sgx_serialize::{SerializeHelper, DeSerializable, DeSerializeHelper};
+use codec::{Input, Decode, Encode};
+
+impl Encode for SgxExternalitiesType {
+	fn encode(&self) -> Vec<u8> {
+		let helper = SerializeHelper::new();
+		helper.encode(self).unwrap()
+	}
+}
+
+impl Decode for SgxExternalitiesType {
+	fn decode<I: Input>(input: &mut I) -> Result<Self, codec::Error> {
+		decode_with_deserialize(input)
+	}
+}
+
+impl Encode for SgxExternalitiesDiffType {
+	fn encode(&self) -> Vec<u8> {
+		let helper = SerializeHelper::new();
+		helper.encode(self.clone()).unwrap()
+	}
+}
+
+impl Decode for SgxExternalitiesDiffType {
+	fn decode<I: Input>(input: &mut I) -> Result<Self, codec::Error> {
+		decode_with_deserialize(input)
+	}
+}
+
+fn decode_with_deserialize<I: Input, T: DeSerializable>(input: &mut I) -> Result<T, codec::Error> {
+	let mut buff = Vec::with_capacity(input.remaining_len()?
+		.ok_or_else(|| codec::Error::from("Could not read length from input data"))?);
+
+	input.read(&mut buff)?;
+
+	DeSerializeHelper::<T>::new(buff).decode().ok_or_else(|| codec::Error::from("Could decode with deserialize"))
+}

--- a/substrate-sgx/externalities/src/lib.rs
+++ b/substrate-sgx/externalities/src/lib.rs
@@ -51,8 +51,8 @@ pub trait SgxExternalitiesTrait: {
 	fn new() -> Self;
 	fn insert(&mut self, k: Vec<u8>, v: Vec<u8>) -> Option<Vec<u8>>;
 	fn remove(&mut self, k: &[u8]) -> Option<Vec<u8>>;
-	fn get(&mut self, k: &[u8]) -> Option<&Vec<u8>>;
-	fn contains_key(&mut self, k: &[u8]) -> bool;
+	fn get(&self, k: &[u8]) -> Option<&Vec<u8>>;
+	fn contains_key(&self, k: &[u8]) -> bool;
 	fn prune_state_diff(&mut self);
 	fn execute_with<R>(&mut self, f: impl FnOnce() -> R) -> R;
 }
@@ -76,12 +76,12 @@ impl SgxExternalitiesTrait for SgxExternalities {
 	}
 
 	/// get value from state of key
-	fn get(&mut self, k: &[u8]) -> Option<&Vec<u8>> {
+	fn get(&self, k: &[u8]) -> Option<&Vec<u8>> {
 		self.state.get(k)
 	}
 
 	/// check if state contains key
-	fn contains_key(&mut self, k: &[u8]) -> bool {
+	fn contains_key(&self, k: &[u8]) -> bool {
 		self.state.contains_key(k)
 	}
 

--- a/substrate-sgx/externalities/src/lib.rs
+++ b/substrate-sgx/externalities/src/lib.rs
@@ -19,18 +19,25 @@
 extern crate sgx_tstd as std;
 
 use std::{collections::HashMap, vec::Vec};
+use codec::{Encode, Decode};
+use derive_more::{From, Deref, DerefMut};
+use environmental::environmental;
 
-#[cfg(not(feature = "std"))]
-use sgx_serialize::{DeSerializeHelper, SerializeHelper};
 #[cfg(not(feature = "std"))]
 use sgx_serialize_derive::{DeSerializable, Serializable};
 
-use environmental::environmental;
+#[cfg(not(feature = "std"))]
+mod codec_impl;
 
-pub type SgxExternalitiesType = HashMap<Vec<u8>, Vec<u8>>;
-pub type SgxExternalitiesDiffType = HashMap<Vec<u8>, Option<Vec<u8>>>;
-
+// new-type pattern to implement `Encode` `Decode` for Hashmap.
 #[cfg_attr(not(feature = "std"), derive(Serializable, DeSerializable))]
+#[derive(From, Deref, DerefMut, Debug, Default, PartialEq, Eq, Clone)]
+pub struct SgxExternalitiesType(HashMap<Vec<u8>, Vec<u8>>);
+#[cfg_attr(not(feature = "std"), derive(Serializable, DeSerializable))]
+#[derive(From, Deref, DerefMut, Debug, Default, PartialEq, Eq, Clone)]
+pub struct SgxExternalitiesDiffType(HashMap<Vec<u8>, Option<Vec<u8>>>);
+
+#[cfg_attr(not(feature = "std"), derive(Serializable, DeSerializable, Encode, Decode))]
 #[derive(Debug, Clone)]
 pub struct SgxExternalities {
 	pub state: SgxExternalitiesType,
@@ -39,10 +46,8 @@ pub struct SgxExternalities {
 
 environmental!(ext: SgxExternalities);
 
-pub trait SgxExternalitiesTrait {
+pub trait SgxExternalitiesTrait: {
 	fn new() -> Self;
-	fn decode(state: Vec<u8>) -> Self;
-	fn encode(self) -> Vec<u8>;
 	fn insert(&mut self, k: Vec<u8>, v: Vec<u8>) -> Option<Vec<u8>>;
 	fn remove(&mut self, k: &[u8]) -> Option<Vec<u8>>;
 	fn get(&mut self, k: &[u8]) -> Option<&Vec<u8>>;
@@ -51,45 +56,18 @@ pub trait SgxExternalitiesTrait {
 	fn execute_with<R>(&mut self, f: impl FnOnce() -> R) -> R;
 }
 
-pub trait SgxExternalitiesTypeTrait {
-	fn new() -> Self;
-	fn decode(state: Vec<u8>) -> Self;
-	fn encode(self) -> Vec<u8>;
-}
-
-#[cfg(not(feature = "std"))]
-impl SgxExternalitiesTypeTrait for SgxExternalitiesType {
+impl SgxExternalitiesType {
 	fn new() -> Self {
 		Default::default()
 	}
-	fn decode(state: Vec<u8>) -> Self {
-		let helper = DeSerializeHelper::<SgxExternalitiesType>::new(state);
-		helper.decode().unwrap()
-	}
-
-	fn encode(self) -> Vec<u8> {
-		let helper = SerializeHelper::new();
-		helper.encode(self).unwrap()
-	}
 }
 
-#[cfg(not(feature = "std"))]
-impl SgxExternalitiesTypeTrait for SgxExternalitiesDiffType {
+impl SgxExternalitiesDiffType {
 	fn new() -> Self {
 		Default::default()
 	}
-	fn decode(state: Vec<u8>) -> Self {
-		let helper = DeSerializeHelper::<SgxExternalitiesDiffType>::new(state);
-		helper.decode().unwrap()
-	}
-
-	fn encode(self) -> Vec<u8> {
-		let helper = SerializeHelper::new();
-		helper.encode(self).unwrap()
-	}
 }
 
-#[cfg(not(feature = "std"))]
 impl SgxExternalitiesTrait for SgxExternalities {
 	/// Create a new instance of `BasicExternalities`
 	fn new() -> Self {
@@ -97,16 +75,6 @@ impl SgxExternalitiesTrait for SgxExternalities {
 			state: SgxExternalitiesType::new(),
 			state_diff: SgxExternalitiesDiffType::new(),
 		}
-	}
-
-	fn decode(state: Vec<u8>) -> Self {
-		let helper = DeSerializeHelper::<SgxExternalities>::new(state);
-		helper.decode().unwrap()
-	}
-
-	fn encode(self) -> Vec<u8> {
-		let helper = SerializeHelper::new();
-		helper.encode(self).unwrap()
 	}
 
 	/// Insert key/value

--- a/substrate-sgx/externalities/src/lib.rs
+++ b/substrate-sgx/externalities/src/lib.rs
@@ -31,14 +31,15 @@ mod codec_impl;
 
 // new-type pattern to implement `Encode` `Decode` for Hashmap.
 #[cfg_attr(not(feature = "std"), derive(Serializable, DeSerializable))]
-#[derive(From, Deref, DerefMut, Debug, Default, PartialEq, Eq, Clone)]
+#[derive(From, Deref, DerefMut, Clone, Debug, Default, PartialEq, Eq)]
 pub struct SgxExternalitiesType(HashMap<Vec<u8>, Vec<u8>>);
+
 #[cfg_attr(not(feature = "std"), derive(Serializable, DeSerializable))]
-#[derive(From, Deref, DerefMut, Debug, Default, PartialEq, Eq, Clone)]
+#[derive(From, Deref, DerefMut, Clone, Debug, Default, PartialEq, Eq)]
 pub struct SgxExternalitiesDiffType(HashMap<Vec<u8>, Option<Vec<u8>>>);
 
 #[cfg_attr(not(feature = "std"), derive(Serializable, DeSerializable, Encode, Decode))]
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct SgxExternalities {
 	pub state: SgxExternalitiesType,
 	pub state_diff: SgxExternalitiesDiffType,
@@ -56,25 +57,10 @@ pub trait SgxExternalitiesTrait: {
 	fn execute_with<R>(&mut self, f: impl FnOnce() -> R) -> R;
 }
 
-impl SgxExternalitiesType {
-	fn new() -> Self {
-		Default::default()
-	}
-}
-
-impl SgxExternalitiesDiffType {
-	fn new() -> Self {
-		Default::default()
-	}
-}
-
 impl SgxExternalitiesTrait for SgxExternalities {
 	/// Create a new instance of `BasicExternalities`
 	fn new() -> Self {
-		SgxExternalities {
-			state: SgxExternalitiesType::new(),
-			state_diff: SgxExternalitiesDiffType::new(),
-		}
+		Default::default()
 	}
 
 	/// Insert key/value

--- a/substrate-sgx/externalities/src/lib.rs
+++ b/substrate-sgx/externalities/src/lib.rs
@@ -1,27 +1,27 @@
 /*
-    Copyright 2021 Integritee AG and Supercomputing Systems AG
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
 
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+		http://www.apache.org/licenses/LICENSE-2.0
 
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
 */
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(not(feature = "std"))]
 extern crate sgx_tstd as std;
 
-use std::{collections::HashMap, vec::Vec};
-use codec::{Encode, Decode};
-use derive_more::{From, Deref, DerefMut};
+use codec::{Decode, Encode};
+use derive_more::{Deref, DerefMut, From};
 use environmental::environmental;
+use std::{collections::HashMap, vec::Vec};
 
 #[cfg(not(feature = "std"))]
 use sgx_serialize_derive::{DeSerializable, Serializable};
@@ -47,7 +47,7 @@ pub struct SgxExternalities {
 
 environmental!(ext: SgxExternalities);
 
-pub trait SgxExternalitiesTrait: {
+pub trait SgxExternalitiesTrait {
 	fn new() -> Self;
 	fn insert(&mut self, k: Vec<u8>, v: Vec<u8>) -> Option<Vec<u8>>;
 	fn remove(&mut self, k: &[u8]) -> Option<Vec<u8>>;


### PR DESCRIPTION
This was motivated because we always need to handle the state-diff differently in the integritee-worker because it does not implement the codec. Further, the encoding before needlessly consumed `self.`

* Closes #10.

Other minors:
* Downgrade `&mut self` to `&self` where it makes sense. Closes #20.
* Remove useless `new()` constructors and derive `Default` instead.

Edit: These are breaking changes.