### PR TITLE
Move verifier to pallets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1424,7 +1424,7 @@ dependencies = [
 [[package]]
 name = "pallet-parentchain"
 version = "0.9.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=master#aa9f9b8754574d2fb86a4b387075d951aa39d64f"
+source = "git+https://github.com/integritee-network/pallets.git?branch=master#1cc6637a517e62215c5e074df8652245f79e3cb3"
 dependencies = [
  "frame-support",
  "frame-system",


### PR DESCRIPTION
Part of https://github.com/integritee-network/pallets/issues/58

- move verification method from worker to pallets repository
- move block builders for tests from worker to pallets repository